### PR TITLE
ci(deps): fix `git push` during `yarn.lock` deduplication for Dependabot PRs [actions testing PR]

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -417,7 +417,7 @@ jobs:
       - run: yarn --cwd ui deduplicate
       # Deduplicate UI deps for dependabot PRs
       - name: Commit deduplicated yarn.lock for Dependabot PRs
-        if: github.actor == 'dependabot[bot]'
+        # if: github.actor == 'dependabot[bot]'
         run: |
           # skip script if there were no changes from deduplicate
           if git diff --quiet -- ui/yarn.lock ; then

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -407,6 +407,8 @@ jobs:
       NODE_OPTIONS: --max-old-space-size=4096
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 50 # assume PRs are less than 50 commits -- fetch-depth is necessary in order to be able to push
       - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
           node-version: "20" # change in all GH Workflows
@@ -430,8 +432,6 @@ jobs:
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git add ui/yarn.lock
           git commit -s --allow-empty -m 'chore: deduplicate yarn.lock'
-          # we are checked out on a detached HEAD, so need to fetch the branch and specify it in order to push
-          git fetch origin $GITHUB_HEAD_REF
           git push origin HEAD:$GITHUB_HEAD_REF
       # if lint or deduplicate make changes that are not in the PR, fail the build
       - name: Check if lint & deduplicate made changes not present in the PR

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -419,11 +419,16 @@ jobs:
       - name: Commit deduplicated yarn.lock for Dependabot PRs
         if: github.actor == 'dependabot[bot]'
         run: |
+          # skip script if there were no changes from deduplicate
+          if git diff --quiet -- ui/yarn.lock ; then
+            exit 0
+          fi
+
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git add ui/yarn.lock
           git commit -s --allow-empty -m 'chore: deduplicate yarn.lock'
-          git push
+          git push origin HEAD:$GITHUB_HEAD_REF
       # if lint or deduplicate make changes that are not in the PR, fail the build
       - name: Check if lint & deduplicate made changes not present in the PR
         run: git diff --exit-code

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -399,6 +399,8 @@ jobs:
     name: UI
     needs: [ changed-files ]
     if: ${{ needs.changed-files.outputs.ui == 'true' }}
+    permissions:
+      contents: write # for pushing deduplicated yarn.lock for dependabot PRs
     runs-on: ubuntu-latest
     timeout-minutes: 6
     env:

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -407,6 +407,8 @@ jobs:
       NODE_OPTIONS: --max-old-space-size=4096
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 50 # assume PRs are less than 50 commits -- fetch-depth is necessary in order to be able to push
       - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
           node-version: "20" # change in all GH Workflows

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -432,7 +432,7 @@ jobs:
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git add ui/yarn.lock
           git commit -s --allow-empty -m 'chore: deduplicate yarn.lock'
-          git push origin HEAD:$GITHUB_HEAD_REF
+          git push origin HEAD:$GITHUB_HEAD_REF # we are checked out on a detached HEAD, so need to specify branch
       # if lint or deduplicate make changes that are not in the PR, fail the build
       - name: Check if lint & deduplicate made changes not present in the PR
         run: git diff --exit-code

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -407,8 +407,6 @@ jobs:
       NODE_OPTIONS: --max-old-space-size=4096
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          fetch-depth: 50 # assume PRs are less than 50 commits -- fetch-depth is necessary in order to be able to push
       - uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8 # v4.0.1
         with:
           node-version: "20" # change in all GH Workflows
@@ -432,6 +430,8 @@ jobs:
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git add ui/yarn.lock
           git commit -s --allow-empty -m 'chore: deduplicate yarn.lock'
+          # we are checked out on a detached HEAD, so need to fetch the branch and specify it in order to push
+          git fetch origin $GITHUB_HEAD_REF
           git push origin HEAD:$GITHUB_HEAD_REF
       # if lint or deduplicate make changes that are not in the PR, fail the build
       - name: Check if lint & deduplicate made changes not present in the PR

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -10421,9 +10421,6 @@ undici-types@~5.26.4:
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 undici@^5.24.0:
-  version "5.24.0"
-
-undici@^5.24.0:
   version "5.28.3"
   resolved "https://registry.yarnpkg.com/undici/-/undici-5.28.3.tgz#a731e0eff2c3fcfd41c1169a869062be222d1e5b"
   integrity sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -10421,6 +10421,9 @@ undici-types@~5.26.4:
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 undici@^5.24.0:
+  version "5.24.0"
+
+undici@^5.24.0:
   version "5.28.3"
   resolved "https://registry.yarnpkg.com/undici/-/undici-5.28.3.tgz#a731e0eff2c3fcfd41c1169a869062be222d1e5b"
   integrity sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -- this is rendered within existing HTML, so allow starting without an H1 -->

<!--

### Before you open your PR

- Run `make pre-commit -B` to fix codegen and lint problems (build will fail).
- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

<!-- Does this PR fix an issue -->

Fixes https://github.com/argoproj/argo-workflows/pull/12234#discussion_r1552552191, https://github.com/argoproj/argo-workflows/pull/12891#issuecomment-2038408649

### Motivation

<!-- TODO: Say why you made your changes. -->

- `actions/checkout` runs `git checkout` on a specific commit SHA, meaning there is no "branch" by default, it's on a detached `HEAD`
  - so without a branch specified, `git push` would error out

### Modifications

<!-- TODO: Say what changes you made. -->
<!-- TODO: Attach screenshots if you changed the UI. -->

- specify a branch for `git push` using [GH Actions env vars](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)
    - note that `$GITHUB_HEAD_REF` should exist for PRs, and dependabot makes PRs (vs. direct `push`es)
  - use `origin` as the remote name which is the default and also was mentioned in the error message
- add `permissions.contents: write` to allow for this GHA job to `push`
- add `fetch-depth` to `actions/checkout` so that it doesn't fail to `push` due to not having fetched (i.e. not knowing the state of the branch being pushed to)

- also add `if git diff --quiet -- ui/yarn.lock` check to short-circuit the logic if there are no changes to `yarn.lock` (i.e. no deduplication necessary)
  - this should also be less buggy as the later code will only execute when strictly necessary now (basically, when not needed, returns to the previous behavior prior to https://github.com/argoproj/argo-workflows/pull/12234)

### Verification

<!-- TODO: Say how you tested your changes. -->

<details><summary>I tested the short-circuit logic locally:</summary>

1. With no changes, exits properly: 
    ```sh
    ❯ bash
    bash-5.1$ if ! git diff --exit-code -- ui/yarn.lock ; then
                exit 0
              fi
    exit
    ❯
    ```

1. With changes, does not exit:
    ```sh
    ❯ bash
    bash-5.1$ if ! git diff --exit-code -- ui/yarn.lock ; then
                exit 0
              fi
    bash-5.1$
    ```
    
</details>

Otherwise using **_this very PR_** in my own fork for testing purposes

<!--
### Beyond this PR

Thank you for submitting this! Have you ever thought of becoming a Reviewer or Approver on the project?

Argo Workflows is seeking more community involvement and ultimately more [Reviewers and Approvers](https://github.com/argoproj/argoproj/blob/main/community/membership.md) to help keep it viable.
See [Sustainability Effort](https://github.com/argoproj/argo-workflows/blob/main/community/sustainability_effort.md) for more information.

-->
